### PR TITLE
Update ParameterConverters.java

### DIFF
--- a/jbehave-core/src/main/java/org/jbehave/core/steps/ParameterConverters.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/steps/ParameterConverters.java
@@ -124,7 +124,7 @@ public class ParameterConverters {
                 new NumberConverter(NumberFormat.getInstance(locale)),
                 new NumberListConverter(NumberFormat.getInstance(locale), escapedListSeparator),
                 new StringListConverter(escapedListSeparator), new DateConverter(),
-                new EnumConverter(), new EnumListConverter(),
+                new EnumConverter(), new EnumListConverter(escapedListSeparator),
                 new ExamplesTableConverter(tableFactory), new ExamplesTableParametersConverter(tableFactory) };
         return defaultConverters;
     }


### PR DESCRIPTION
Use incoming listSeparator instead of the default DEFAULT_LIST_SEPARATOR for EnumListConverter when creating default converters.