### PR TITLE
Fixed JBEHAVE-1057: Upgrade to xunit-plugin version 1.93

### DIFF
--- a/jbehave-jenkins-plugin/pom.xml
+++ b/jbehave-jenkins-plugin/pom.xml
@@ -11,10 +11,10 @@
   <url>http://jbehave.org/reference/stable/hudson-plugin.html</url>
 
   <properties>
-    <hudson.test.harness.version>1.395</hudson.test.harness.version>
-    <hudson.version>2.2.1</hudson.version>
-    <hpi.plugin.version>3.0.1</hpi.plugin.version>
-    <xunit.plugin.version>1.62</xunit.plugin.version>
+    <jenkins.test.harness.version>1.594</jenkins.test.harness.version>
+    <jenkins.version>1.594</jenkins.version>
+    <hpi.plugin.version>1.112</hpi.plugin.version>
+    <xunit.plugin.version>1.93</xunit.plugin.version>
   </properties>
 
   <dependencies>
@@ -30,9 +30,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.hudson.main</groupId>
-      <artifactId>hudson-core</artifactId>
-      <version>${hudson.version}</version>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <version>${jenkins.version}</version>
       <scope>provided</scope>
       <exclusions>
       	<exclusion>
@@ -42,16 +42,16 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.hudson.main</groupId>
-      <artifactId>hudson-war</artifactId>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-war</artifactId>
       <type>war</type>
-      <version>${hudson.version}</version>
+      <version>${jenkins.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.hudson.main</groupId>
-      <artifactId>hudson-test-harness</artifactId>
-      <version>${hudson.test.harness.version}</version>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness</artifactId>
+      <version>${jenkins.test.harness.version}</version>
       <scope>test</scope>
       <exclusions>
       	<exclusion>
@@ -94,7 +94,7 @@
     <defaultGoal>package</defaultGoal>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.hudson.tools</groupId>
+        <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <version>${hpi.plugin.version}</version>
         <extensions>true</extensions>

--- a/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/JBehaveInputMetric.java
+++ b/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/JBehaveInputMetric.java
@@ -1,8 +1,8 @@
 package org.jbehave.jenkins;
 
-import com.thalesgroup.dtkit.metrics.model.InputMetricXSL;
-import com.thalesgroup.dtkit.metrics.model.InputType;
-import com.thalesgroup.dtkit.metrics.model.OutputMetric;
+import org.jenkinsci.lib.dtkit.model.InputMetricXSL;
+import org.jenkinsci.lib.dtkit.model.InputType;
+import org.jenkinsci.lib.dtkit.model.OutputMetric;
 
 @SuppressWarnings("serial")
 public class JBehaveInputMetric extends InputMetricXSL {

--- a/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/JBehavePluginType.java
+++ b/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/JBehavePluginType.java
@@ -2,8 +2,8 @@ package org.jbehave.jenkins;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import com.thalesgroup.dtkit.metrics.hudson.api.descriptor.TestTypeDescriptor;
-import com.thalesgroup.dtkit.metrics.hudson.api.type.TestType;
+import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
+import org.jenkinsci.lib.dtkit.type.TestType;
 
 import hudson.Extension;
 

--- a/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/JBehaveType.java
+++ b/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/JBehaveType.java
@@ -16,7 +16,7 @@ public class JBehaveType extends TestType {
     }
 
     public Object readResolve() {
-        return new JBehavePluginType(this.getPattern(), this.isFailIfNotNew(), false, this.isStopProcessingIfError());
+        return new JBehavePluginType(this.getPattern(), this.isFailIfNotNew(), this.isDeleteOutputFiles(), this.isStopProcessingIfError());
     }
 
 }

--- a/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/JBehaveType.java
+++ b/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/JBehaveType.java
@@ -1,10 +1,10 @@
 package org.jbehave.jenkins;
 
-import com.thalesgroup.dtkit.metrics.hudson.api.descriptor.TestTypeDescriptor;
-import com.thalesgroup.hudson.plugins.xunit.types.XUnitType;
+import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
+import org.jenkinsci.lib.dtkit.type.TestType;
 
 @SuppressWarnings("serial")
-public class JBehaveType extends XUnitType {
+public class JBehaveType extends TestType {
 
     public JBehaveType(String pattern, boolean failedIfNotNew, boolean deleteJUnitFiles) {
         super(pattern, failedIfNotNew, deleteJUnitFiles);
@@ -16,7 +16,7 @@ public class JBehaveType extends XUnitType {
     }
 
     public Object readResolve() {
-        return new JBehavePluginType(this.getPattern(), this.isFailIfNotNew(), this.isDeleteJUnitFiles(), this.isStopProcessingIfError());
+        return new JBehavePluginType(this.getPattern(), this.isFailIfNotNew(), false, this.isStopProcessingIfError());
     }
 
 }

--- a/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/MavenSurefireModel.java
+++ b/jbehave-jenkins-plugin/src/main/java/org/jbehave/jenkins/MavenSurefireModel.java
@@ -1,8 +1,8 @@
 package org.jbehave.jenkins;
 
-import java.io.Serializable;
+import org.jenkinsci.lib.dtkit.model.AbstractOutputMetric;
 
-import com.thalesgroup.dtkit.metrics.model.AbstractOutputMetric;
+import java.io.Serializable;
 
 @SuppressWarnings("serial")
 public class MavenSurefireModel extends AbstractOutputMetric implements Serializable {

--- a/settings.xml
+++ b/settings.xml
@@ -68,13 +68,13 @@
       <repositories>
         <repository>
           <id>jenkins</id>
-          <url>http://maven.jenkins-ci.org/content/repositories/releases/</url>
+          <url>http://repo.jenkins-ci.org/releases/</url>
         </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
           <id>jenkins</id>
-          <url>http://maven.jenkins-ci.org/content/repositories/releases/</url>
+          <url>http://repo.jenkins-ci.org/releases/</url>
         </pluginRepository>
       </pluginRepositories>
     </profile>


### PR DESCRIPTION
I needed to change the jenkins repositories and switched from hudson to the equivalent jenkins dependencies. This version worked fine on my jenkins server with `xunit-plugin` installed in version `1.93`.

The code does also compile with `xunit` version `1.92`.

I'm a bit unsure if the replacement from `XUnitType` by `TestType` is correct. It would be great if you could review that change and could give me some feedback.