### PR TITLE
Writing stories in plain English, with words convertible to boolean

### DIFF
--- a/jbehave-core/src/main/java/org/jbehave/core/steps/BooleanWord.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/steps/BooleanWord.java
@@ -1,0 +1,65 @@
+package org.jbehave.core.steps;
+
+/**
+ * Plain English expressions convertible to booleans, to be used as parameters of
+ * candidate steps.
+ * <p>
+ * It requires {@link ParameterConverters.FluentEnumConverter} to be configured
+ * as the {@link ParameterConverters.ParameterConverter} for enums.
+ * <p>
+ * Example of use.
+ * 
+ * Given the following candidate step:
+ * <pre>
+ * @Given("a stock of symbol $symbol $withThreshold a threshold")
+ * public void aStock(String symbol, BooleanWord withThreshold) {
+ *     stock = new Stock(symbol).withThreshold(withThreshold.toBoolean());
+ * }
+ * </pre>
+ * 
+ * .. it is then possible to write the following scenarios:
+ * 
+ * <pre>
+ * Scenario: a stock with threshold
+ * 
+ * Given a stock of symbol AAA <b>with</b> a threshold
+ * When ..
+ * Then ..
+ * 
+ * Scenario: a stock with no threshold
+ * 
+ * Given a stock of symbol AAA <b>without</b> a threshold
+ * When ..
+ * Then ..
+ * </pre>
+ */
+public enum BooleanWord {
+
+    SHOULD(true),
+    SHOULDN_T(false),
+    SHOULD_NOT(false),
+    CAN(true),
+    CANNOT(false),
+    CAN_T(false),
+    WITH(true),
+    WITHOUT(false),
+    ;
+    
+    private boolean boolVal;
+
+    private BooleanWord(boolean boolValue) {
+        this.boolVal = boolValue;
+    }
+
+    public boolean toBoolean() {
+        return boolVal;
+    }
+
+    /**
+     * Just an alias to {@link #toBoolean()}.
+     */
+    public boolean toBool() {
+        return toBoolean();
+    }
+
+}

--- a/jbehave-core/src/main/resources/i18n/boolean_expressions_en.properties
+++ b/jbehave-core/src/main/resources/i18n/boolean_expressions_en.properties
@@ -1,0 +1,8 @@
+with=true
+without=false
+should=true
+should\ not=false
+shouldn't = false
+can=true
+can't=false
+cannot=false

--- a/jbehave-core/src/main/resources/i18n/boolean_expressions_it.properties
+++ b/jbehave-core/src/main/resources/i18n/boolean_expressions_it.properties
@@ -1,0 +1,6 @@
+con=true
+senza=false
+dovrebbe=true
+non\ dovrebbe=false
+può=true
+non\ può=false

--- a/jbehave-core/src/test/java/org/jbehave/core/steps/ParameterConvertersBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/steps/ParameterConvertersBehaviour.java
@@ -1,6 +1,7 @@
 package org.jbehave.core.steps;
 
 import java.beans.IntrospectionException;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -511,6 +512,42 @@ public class ParameterConvertersBehaviour {
         assertThat((Boolean) converter.convertValue("ON", type), is(true));
         assertThat((Boolean) converter.convertValue("OFF", type), is(false));
         assertThat((Boolean) converter.convertValue("whatever", type), is(false));
+    }
+
+    @Test
+    public void shouldConvertBooleanWithEnglishLocale_positive() {
+        String value = "with";
+        ParameterConverter converter = new BooleanConverter();
+        assertTrue(converter.accept(Boolean.class));
+        Boolean convertedValue = (Boolean) converter.convertValue(value, Boolean.class);
+        assertThat(convertedValue, is(true));
+    }
+
+    @Test
+    public void shouldConvertBooleanWithEnglishLocale_negative() {
+        String value = "without";
+        ParameterConverter converter = new BooleanConverter();
+        assertTrue(converter.accept(Boolean.class));
+        Boolean convertedValue = (Boolean) converter.convertValue(value, Boolean.class);
+        assertThat(convertedValue, is(false));
+    }
+
+    @Test
+    public void shouldConvertBooleanWithNonEnglishLocale_latinCharacters() {
+        String value = "può";
+        ParameterConverter converter = new BooleanConverter().withLocale(Locale.ITALIAN);
+        assertTrue(converter.accept(Boolean.class));
+        Boolean convertedValue = (Boolean) converter.convertValue(value, Boolean.class);
+        assertThat(convertedValue, is(true));
+    }
+
+    @Test
+    public void shouldConvertBooleanWithEnglishLocale() {
+        try {
+            new BooleanConverter().withLocale(Locale.ENGLISH);
+        } catch (ParameterConvertionFailed e) {
+            fail("The resource for the English locale should be loadable.");
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/jbehave-core/src/test/java/org/jbehave/core/steps/ParameterConvertersBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/steps/ParameterConvertersBehaviour.java
@@ -43,6 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -461,8 +462,9 @@ public class ParameterConvertersBehaviour {
     @Test
     public void shouldConvertEnumFluently() {
         ParameterConverter converter = new FluentEnumConverter();
-        assertThat(converter.accept(SomeEnum.class), equalTo(true));
+        assertTrue(converter.accept(SomeEnum.class));
         assertThat((SomeEnum) converter.convertValue("multiple words and 1 number", SomeEnum.class), equalTo(SomeEnum.MULTIPLE_WORDS_AND_1_NUMBER));
+        assertThat((SomeEnum) converter.convertValue("can't", SomeEnum.class), equalTo(SomeEnum.CAN_T));
     }
     
     

--- a/jbehave-core/src/test/java/org/jbehave/core/steps/SomeSteps.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/steps/SomeSteps.java
@@ -171,5 +171,6 @@ enum SomeEnum {
     TWO,
     THREE,
     MULTIPLE_WORDS_AND_1_NUMBER,
+    CAN_T,
     ;
 }


### PR DESCRIPTION
BooleanWord is an enum that allows story writers to write natural prose, while developers can enjoy getting booleans "for free".

Quoting from the javadoc..

Example of use. Given the following candidate step:

```
 @Given("a stock of symbol $symbol $withThreshold a threshold")
 public void aStock(String symbol, BooleanWord withThreshold) {
     stock = new Stock(symbol).withThreshold(withThreshold.toBoolean());
 }
```

.. it is then possible to write the following scenarios:

```
 Scenario: a stock with threshold

 Given a stock of symbol AAA with a threshold
 When ..
 Then ..

 Scenario: a stock with no threshold

 Given a stock of symbol AAA without a threshold
 When ..
 Then ..
```

Please note that this depends on #77.

It would be nice if we could find an elegant way to internationalise the enum constants.
One where there is only one enum constant for each boolean word, and the translations are kept in an external file. Any ideas?
