### PR TITLE
JBEHAVE-1116 Identify and fix false positive or nonfailing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 install: mvn install -s settings.xml -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode -e --quiet
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 script: mvn install -s settings.xml -P examples --batch-mode -e

--- a/examples/core/src/main/java/org/jbehave/examples/core/FailureCorrelationStories.java
+++ b/examples/core/src/main/java/org/jbehave/examples/core/FailureCorrelationStories.java
@@ -14,6 +14,7 @@ import org.jbehave.core.embedder.StoryControls;
 import org.jbehave.core.failures.UUIDExceptionWrapper;
 import org.jbehave.core.io.StoryFinder;
 import org.jbehave.core.steps.CandidateSteps;
+import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
 import org.junit.Assert;
 
@@ -24,8 +25,11 @@ public class FailureCorrelationStories extends CoreStories {
     private List<String> failures = new ArrayList<String>();
 
     public FailureCorrelationStories() {
-        configuredEmbedder().embedderControls().doGenerateViewAfterStories(true).doIgnoreFailureInStories(true)
-                .doIgnoreFailureInView(true).useThreads(1).useStoryTimeouts("60");
+        configuredEmbedder().embedderControls()
+                .doGenerateViewAfterStories(true)
+                .doIgnoreFailureInStories(true)
+                .doIgnoreFailureInView(true)
+                .useThreads(1).useStoryTimeouts("60");
     }
 
     @Override
@@ -34,10 +38,8 @@ public class FailureCorrelationStories extends CoreStories {
     }
 
     @Override
-    public List<CandidateSteps> candidateSteps() {
-        List<CandidateSteps> candidateSteps = new ArrayList<CandidateSteps>();
-        candidateSteps.addAll(new InstanceStepsFactory(configuration(), this).createCandidateSteps());
-        return candidateSteps;
+    public InjectableStepsFactory stepsFactory() {
+        return new InstanceStepsFactory(configuration(), this);
     }
 
     @Override

--- a/jbehave-core/src/test/java/org/jbehave/core/configuration/AnnotationBuilderBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/configuration/AnnotationBuilderBehaviour.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -109,6 +110,7 @@ public class AnnotationBuilderBehaviour {
                 new PrintStreamAnnotationMonitor(new PrintStream(baos)));
         try {
             assertThatStepsInstancesAre(annotatedFailing.buildCandidateSteps(), MySteps.class);
+            fail("Exception was not thrown");
         } catch (RuntimeException e) {
             assertThat(baos.toString(), containsString("Element creation failed"));
             assertThat(baos.toString(), containsString("RuntimeException"));
@@ -187,6 +189,7 @@ public class AnnotationBuilderBehaviour {
                 new PrintStreamAnnotationMonitor(new PrintStream(baos)));
         try {
             annotatedPrivate.embeddableInstance();
+            fail("Exception was not thrown");
         } catch (InstantiationFailed e) {
             assertThat(baos.toString(), containsString("Element creation failed"));
             assertThat(baos.toString(), containsString("IllegalAccessException"));

--- a/jbehave-core/src/test/java/org/jbehave/core/embedder/ConcurrencyBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/embedder/ConcurrencyBehaviour.java
@@ -8,6 +8,7 @@ import static org.jbehave.core.io.CodeLocations.codeLocationFromClass;
 import static org.jbehave.core.reporters.Format.CONSOLE;
 import static org.jbehave.core.reporters.Format.HTML;
 import static org.jbehave.core.reporters.Format.XML;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -47,6 +48,7 @@ public class ConcurrencyBehaviour {
         embedder.embedderControls().useStoryTimeouts("1");
         try {
             embedder.runAsEmbeddables(asList(XmlFormat.class.getName()));
+            fail("Exception was not thrown");
         } catch (RunningEmbeddablesFailed e) {
             String xmlOutput = XmlFormat.out.toString();
             assertThat(xmlOutput, containsString("</scenario>"));
@@ -86,6 +88,7 @@ public class ConcurrencyBehaviour {
 				.doFailOnStoryTimeout(true);
 		try {
 			embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
+			fail("Exception was not thrown");
 		} catch (RunningEmbeddablesFailed e) {
 			assertThat(e.getCause(), instanceOf(StoryExecutionFailed.class));
 			assertThat(e.getCause().getCause(), instanceOf(StoryTimedOut.class));
@@ -98,6 +101,7 @@ public class ConcurrencyBehaviour {
          embedder.embedderControls().useStoryTimeouts("**/*.story:1").doFailOnStoryTimeout(true);
          try {
              embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
+             fail("Exception was not thrown");
          } catch (RunningEmbeddablesFailed e) {
             assertThat(e.getCause(), instanceOf(StoryExecutionFailed.class));
             assertThat(e.getCause().getCause(), instanceOf(StoryTimedOut.class));
@@ -120,13 +124,13 @@ public class ConcurrencyBehaviour {
 	     Embedder embedder = new Embedder(embedderMonitor(out));
 		 try {
 			 embedder.embedderControls().useStoryTimeouts("**/another_long.story:1").doFailOnStoryTimeout(true);
-		   	 embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
-		   	    
-	        } catch (RunningEmbeddablesFailed e) {
-	        	assertThat(out.toString(), containsString("Using timeout for story a_short.story of 300"));
-	        	assertThat(out.toString(), containsString("Using timeout for story a_long.story of 300"));
-	        	assertThat(out.toString(), containsString("Using timeout for story another_long.story of 1"));
-	        }
+			 embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
+			 fail("Exception was not thrown");
+		 } catch (RunningEmbeddablesFailed e) {
+			 assertThat(out.toString(), containsString("Using timeout for story a_short.story of 300"));
+			 assertThat(out.toString(), containsString("Using timeout for story a_long.story of 300"));
+			 assertThat(out.toString(), containsString("Using timeout for story another_long.story of 1"));
+		 }
 	 }
 	 
 	 @Test
@@ -136,11 +140,12 @@ public class ConcurrencyBehaviour {
 		 try {
 			 embedder.embedderControls().useStoryTimeouts("10,**/a_short.story:1,**/another_long.story:2").doFailOnStoryTimeout(true);
 		   	 embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
-	        } catch (RunningEmbeddablesFailed e) {
-	        	assertThat(out.toString(), containsString("Using timeout for story a_short.story of 1"));
-	        	assertThat(out.toString(), containsString("Using timeout for story a_long.story of 10"));
-	        	assertThat(out.toString(), containsString("Using timeout for story another_long.story of 2"));
-	        }
+			 fail("Exception was not thrown");
+		 } catch (RunningEmbeddablesFailed e) {
+			 assertThat(out.toString(), containsString("Using timeout for story a_short.story of 1"));
+			 assertThat(out.toString(), containsString("Using timeout for story a_long.story of 10"));
+			 assertThat(out.toString(), containsString("Using timeout for story another_long.story of 2"));
+		}
 	 }
 	 
 	 @Test
@@ -161,11 +166,11 @@ public class ConcurrencyBehaviour {
 		 try {
 			 ThreadsStories.setCustomStoryPath("**/another_long.story");
 			 embedder.embedderControls().useStoryTimeouts("**/another_long.story:0").doFailOnStoryTimeout(true);
-		   	 embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));  
-	        } catch (RunningEmbeddablesFailed e) {
-	        	assertThat(out.toString(), containsString("Using timeout for story another_long.story of 0"));
-	        }
-		 finally {
+			 embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
+			 fail("Exception was not thrown");
+		 } catch (RunningEmbeddablesFailed e) {
+			 assertThat(out.toString(), containsString("Using timeout for story another_long.story of 0"));
+		 } finally {
 			 ThreadsStories.setCustomStoryPath(null);
 		 }
 	 }
@@ -208,6 +213,7 @@ public class ConcurrencyBehaviour {
 			embedder.embedderControls().useStoryTimeouts(storyTimeouts)
 					.doFailOnStoryTimeout(true);
 			embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
+			fail("Exception was not thrown");
 		} catch (RunningEmbeddablesFailed e) {
 			assertThat(e.getCause(), instanceOf(TimeoutFormatException.class));
 		}

--- a/jbehave-core/src/test/java/org/jbehave/core/embedder/ConcurrencyBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/embedder/ConcurrencyBehaviour.java
@@ -160,19 +160,14 @@ public class ConcurrencyBehaviour {
 	 }
 	 
 	 @Test
-	 public void shouldAllowTimeoutByPathToBeZero() {
+	 public void shouldAllowTimeoutByPathToBeZeroMeaningNoTimeLimit() {
 	     OutputStream out = new ByteArrayOutputStream();
 	     Embedder embedder = new Embedder(embedderMonitor(out));
-		 try {
-			 ThreadsStories.setCustomStoryPath("**/another_long.story");
-			 embedder.embedderControls().useStoryTimeouts("**/another_long.story:0").doFailOnStoryTimeout(true);
-			 embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
-			 fail("Exception was not thrown");
-		 } catch (RunningEmbeddablesFailed e) {
-			 assertThat(out.toString(), containsString("Using timeout for story another_long.story of 0"));
-		 } finally {
-			 ThreadsStories.setCustomStoryPath(null);
-		 }
+		 ThreadsStories.setCustomStoryPath("**/another_long.story");
+		 embedder.embedderControls().useStoryTimeouts("**/another_long.story:0").doFailOnStoryTimeout(true);
+		 embedder.runAsEmbeddables(asList(ThreadsStories.class.getName()));
+		 assertThat(out.toString(), containsString("Using timeout for story another_long.story of 0"));
+		 ThreadsStories.setCustomStoryPath(null);
 	 }
 	 
 	 @Test

--- a/jbehave-core/src/test/java/org/jbehave/core/io/IOUtilsBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/io/IOUtilsBehaviour.java
@@ -63,17 +63,15 @@ public class IOUtilsBehaviour {
         verify(reader, never()).close();
     }
 
-    @Test
+    @Test(expected = IOException.class)
     public void shouldCloseReaderException() throws IOException {
         Reader reader = mock(Reader.class);
         when(reader.read(isA(char[].class))).thenThrow(new IOException());
         try {
             IOUtils.toString(reader, true);
+        } finally {
+            verify(reader).close();
         }
-        catch(IOException ioex) {
-            // expected
-        }
-        verify(reader).close();
     }
 
     // same for InputStream
@@ -118,17 +116,15 @@ public class IOUtilsBehaviour {
         verify(stream, never()).close();
     }
 
-    @Test
+    @Test(expected = IOException.class)
     public void shouldCloseInputStreamException() throws IOException {
         InputStream stream = mock(InputStream.class);
         when(stream.read(isA(byte[].class), anyInt(), anyInt())).thenThrow(new IOException());
         try {
             IOUtils.toString(stream, true);
+        } finally {
+            verify(stream).close();
         }
-        catch(IOException ioex) {
-            // expected
-        }
-        verify(stream).close();
     }
 
     /*

--- a/jbehave-core/src/test/java/org/jbehave/core/model/ExamplesTableBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/model/ExamplesTableBehaviour.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.fail;
 
 public class ExamplesTableBehaviour {
 
@@ -424,11 +425,13 @@ public class ExamplesTableBehaviour {
         assertThat(integers.valueAs("one", Integer.class), equalTo(11));
         try {
             integers.valueAs("unknown", Integer.class);
+            fail("Exception was not thrown");
         } catch (ValueNotFound e) {
             assertThat(e.getMessage(), equalTo("unknown"));
         }
         try {
             examplesTable.getRowAsParameters(1);
+            fail("Exception was not thrown");
         } catch (RowNotFound e) {
             assertThat(e.getMessage(), equalTo("1"));
         }

--- a/jbehave-core/src/test/java/org/jbehave/core/model/OutcomesTableBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/model/OutcomesTableBehaviour.java
@@ -10,6 +10,7 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 
 public class OutcomesTableBehaviour {
 
@@ -35,6 +36,7 @@ public class OutcomesTableBehaviour {
         table.addOutcome("a failure", two, is(false));
         try {
             table.verify();
+            fail("Exception was not thrown");
         } catch (UUIDExceptionWrapper ce) {
             OutcomesFailed e = (OutcomesFailed) ce.getCause();
             assertThat(e.outcomesTable().getOutcomes().size(), equalTo(2));

--- a/jbehave-core/src/test/java/org/jbehave/core/steps/ParameterConvertersBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/steps/ParameterConvertersBehaviour.java
@@ -210,28 +210,24 @@ public class ParameterConvertersBehaviour {
 
     @Test
     public void shouldFailToConvertInvalidNumbersWithNumberFormat() {
-        boolean hasFailed = false;
         NumberConverter converter = new NumberConverter();
         try {
             converter.convertValue("abc", Long.class);
+            fail("Exception was not thrown");
         } catch (ParameterConvertionFailed e) {
-            hasFailed = true;
             assertThat(e.getCause(), is(instanceOf(ParseException.class)));
         }
-        assertThat("Conversion has not failed", hasFailed);
     }
 
     @Test
     public void shouldFailToConvertInvalidNumbersWithNumberFormat2()  {
-        boolean hasFailed = false;
         NumberConverter converter = new NumberConverter();
         try {
             converter.convertValue("12.34.56", BigDecimal.class);
+            fail("Exception was not thrown");
         } catch (ParameterConvertionFailed e) {
-            hasFailed = true;
             assertThat(e.getCause(), is(instanceOf(NumberFormatException.class)));
         }
-        assertThat("Conversion has not failed", hasFailed);
     }
 
     @Test


### PR DESCRIPTION
Hi all,

List of changes
* Updated Travis configuration to use jdk8 as test is failing on jdk7 most likely due to the set items order
* added fail("Expected exception") after api calls in test cases that expects exceptions
* Updated one of the examples to use non-deprecated API.
