### PR TITLE
[JBEHAVE-1100] Revert "JBEHAVE-1084: Avoid recreating StoryManager"

### DIFF
--- a/jbehave-core/src/main/java/org/jbehave/core/embedder/Embedder.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/embedder/Embedder.java
@@ -205,7 +205,7 @@ public class Embedder {
         try {
 
             // set up run context
-            StoryManager storyManager = storyManager();
+            StoryManager storyManager = createStoryManager();
             MetaFilter filter = metaFilter();
             BatchFailures failures = new BatchFailures(embedderControls.verboseFailures());
 


### PR DESCRIPTION
This reverts commit 82890d839de9ce905fc208f2ec21b8ee9c8a6959 and fixes JBEHAVE-1100.

It does not seem worth to have this blocking bug open for such a long period and over so many releases. Even because the commit does not fix JBEHAVE-1084, because currently it is not possible to execute several stories at all. Therefore I suggest, with this PR, to revert the commit that introduced the bug. 