### PR TITLE
disable printing all stories when using gherkin format

### DIFF
--- a/jbehave-gherkin/src/main/java/org/jbehave/core/parsers/gherkin/GherkinStoryParser.java
+++ b/jbehave-gherkin/src/main/java/org/jbehave/core/parsers/gherkin/GherkinStoryParser.java
@@ -172,7 +172,6 @@ public class GherkinStoryParser extends TransformingStoryParser {
 
 			};
 			new Parser(formatter).parse(storyAsText, "", 0);
-			System.out.println(out.toString());
 			return out.toString();
 		}
 	}


### PR DESCRIPTION
Disable jbehave printing all gherkins stories
when it parses them into stdout, which created
a lot of noise.