### PR TITLE
Add possibility to define templates

### DIFF
--- a/jbehave-core/src/main/java/org/jbehave/core/configuration/Keywords.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/configuration/Keywords.java
@@ -22,6 +22,8 @@ public class Keywords {
 
     private static final String SYNONYM_SEPARATOR = "\\|";
     
+
+    public static final String TEMPLATE ="Template";
     public static final String META = "Meta";
     public static final String META_PROPERTY = "MetaProperty";
     public static final String NARRATIVE = "Narrative";
@@ -66,7 +68,7 @@ public class Keywords {
             SCENARIO, GIVEN_STORIES, LIFECYCLE, BEFORE, AFTER, EXAMPLES_TABLE, EXAMPLES_TABLE_ROW, EXAMPLES_TABLE_HEADER_SEPARATOR,
             EXAMPLES_TABLE_VALUE_SEPARATOR, EXAMPLES_TABLE_IGNORABLE_SEPARATOR, GIVEN, WHEN, THEN, AND, IGNORABLE,
             PENDING, NOT_PERFORMED, FAILED, DRY_RUN, STORY_CANCELLED, DURATION, OUTCOME, OUTCOME_ANY, OUTCOME_SUCCESS, OUTCOME_FAILURE,
-            OUTCOME_DESCRIPTION, OUTCOME_VALUE, OUTCOME_MATCHER, OUTCOME_VERIFIED, META_FILTER, YES, NO);
+            OUTCOME_DESCRIPTION, OUTCOME_VALUE, OUTCOME_MATCHER, OUTCOME_VERIFIED, META_FILTER, YES, NO, TEMPLATE);
 
 
     private final String meta;
@@ -109,6 +111,7 @@ public class Keywords {
     private final String yes;
     private final String no;
     private final Map<StepType, String> startingWordsByType = new HashMap<StepType, String>();
+    private final String template;
 
 
     public static Map<String, String> defaultKeywords() {
@@ -152,6 +155,7 @@ public class Keywords {
         keywords.put(META_FILTER, "MetaFilter:");
         keywords.put(YES, "Yes");
         keywords.put(NO, "No");
+        keywords.put(TEMPLATE, "Template:");
         return keywords;
     }
 
@@ -207,6 +211,7 @@ public class Keywords {
         this.metaFilter = keyword(META_FILTER, keywords);
         this.yes = keyword(YES, keywords);
         this.no = keyword(NO, keywords);
+        this.template = keyword(TEMPLATE, keywords);
 
         startingWordsByType.put(StepType.GIVEN, given());
         startingWordsByType.put(StepType.WHEN, when());
@@ -222,6 +227,10 @@ public class Keywords {
             throw new KeywordNotFound(name, keywords);
         }
         return keyword;
+    }
+
+    public String template() {
+        return template;
     }
 
     public String meta() {

--- a/jbehave-core/src/main/java/org/jbehave/core/configuration/Keywords.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/configuration/Keywords.java
@@ -21,9 +21,10 @@ import static java.util.Arrays.asList;
 public class Keywords {
 
     private static final String SYNONYM_SEPARATOR = "\\|";
-    
 
     public static final String TEMPLATE ="Template";
+    public static final String GIVEN_TEMPLATE ="GivenTemplate";
+
     public static final String META = "Meta";
     public static final String META_PROPERTY = "MetaProperty";
     public static final String NARRATIVE = "Narrative";
@@ -68,7 +69,7 @@ public class Keywords {
             SCENARIO, GIVEN_STORIES, LIFECYCLE, BEFORE, AFTER, EXAMPLES_TABLE, EXAMPLES_TABLE_ROW, EXAMPLES_TABLE_HEADER_SEPARATOR,
             EXAMPLES_TABLE_VALUE_SEPARATOR, EXAMPLES_TABLE_IGNORABLE_SEPARATOR, GIVEN, WHEN, THEN, AND, IGNORABLE,
             PENDING, NOT_PERFORMED, FAILED, DRY_RUN, STORY_CANCELLED, DURATION, OUTCOME, OUTCOME_ANY, OUTCOME_SUCCESS, OUTCOME_FAILURE,
-            OUTCOME_DESCRIPTION, OUTCOME_VALUE, OUTCOME_MATCHER, OUTCOME_VERIFIED, META_FILTER, YES, NO, TEMPLATE);
+            OUTCOME_DESCRIPTION, OUTCOME_VALUE, OUTCOME_MATCHER, OUTCOME_VERIFIED, META_FILTER, YES, NO, TEMPLATE, GIVEN_TEMPLATE);
 
 
     private final String meta;
@@ -112,6 +113,7 @@ public class Keywords {
     private final String no;
     private final Map<StepType, String> startingWordsByType = new HashMap<StepType, String>();
     private final String template;
+    private final String givenTemplate;
 
 
     public static Map<String, String> defaultKeywords() {
@@ -155,6 +157,7 @@ public class Keywords {
         keywords.put(META_FILTER, "MetaFilter:");
         keywords.put(YES, "Yes");
         keywords.put(NO, "No");
+        keywords.put(GIVEN_TEMPLATE, "GivenTemplate:");
         keywords.put(TEMPLATE, "Template:");
         return keywords;
     }
@@ -211,6 +214,7 @@ public class Keywords {
         this.metaFilter = keyword(META_FILTER, keywords);
         this.yes = keyword(YES, keywords);
         this.no = keyword(NO, keywords);
+        this.givenTemplate = keyword(GIVEN_TEMPLATE, keywords);
         this.template = keyword(TEMPLATE, keywords);
 
         startingWordsByType.put(StepType.GIVEN, given());
@@ -227,6 +231,10 @@ public class Keywords {
             throw new KeywordNotFound(name, keywords);
         }
         return keyword;
+    }
+
+    public String givenTemplate() {
+        return givenTemplate;
     }
 
     public String template() {

--- a/jbehave-core/src/main/java/org/jbehave/core/model/Template.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/model/Template.java
@@ -1,0 +1,32 @@
+package org.jbehave.core.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Template {
+
+    public static final Template EMPTY = new Template();
+
+    private final String title;
+    private final List<String> steps;
+
+    public Template() {
+        title = "";
+        steps = new ArrayList<String>();
+    }
+
+    public Template(String title, List<String> steps) {
+        this.title = title;
+        this.steps = steps;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public List<String> getSteps() {
+        return steps;
+    }
+
+
+}

--- a/jbehave-core/src/main/java/org/jbehave/core/model/Template.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/model/Template.java
@@ -1,19 +1,11 @@
 package org.jbehave.core.model;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class Template {
 
-    public static final Template EMPTY = new Template();
-
     private final String title;
     private final List<String> steps;
-
-    public Template() {
-        title = "";
-        steps = new ArrayList<String>();
-    }
 
     public Template(String title, List<String> steps) {
         this.title = title;
@@ -27,6 +19,5 @@ public class Template {
     public List<String> getSteps() {
         return steps;
     }
-
 
 }

--- a/jbehave-core/src/main/java/org/jbehave/core/model/Templates.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/model/Templates.java
@@ -21,4 +21,12 @@ public class Templates {
         return templates;
     }
 
+    public Template getTemplateWithTitle(String title) {
+        for (Template template : templates) {
+            if (template.getTitle().equals(title)) {
+                return template;
+            }
+        }
+        return null;
+    }
 }

--- a/jbehave-core/src/main/java/org/jbehave/core/model/Templates.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/model/Templates.java
@@ -1,0 +1,24 @@
+package org.jbehave.core.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Templates {
+
+    public static final Templates EMPTY = new Templates();
+
+    private final List<Template> templates;
+
+    public Templates() {
+        templates = new ArrayList<Template>();
+    }
+
+    public Templates(List<Template> templates) {
+        this.templates = templates;
+    }
+
+    public List<Template> getTemplates() {
+        return templates;
+    }
+
+}

--- a/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexStoryParser.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexStoryParser.java
@@ -15,17 +15,8 @@ import org.jbehave.core.annotations.AfterScenario.Outcome;
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.configuration.Keywords;
 import org.jbehave.core.i18n.LocalizedKeywords;
-import org.jbehave.core.model.Description;
-import org.jbehave.core.model.ExamplesTable;
-import org.jbehave.core.model.ExamplesTableFactory;
-import org.jbehave.core.model.GivenStories;
-import org.jbehave.core.model.Lifecycle;
+import org.jbehave.core.model.*;
 import org.jbehave.core.model.Lifecycle.Steps;
-import org.jbehave.core.model.Meta;
-import org.jbehave.core.model.Narrative;
-import org.jbehave.core.model.Scenario;
-import org.jbehave.core.model.Story;
-import org.jbehave.core.model.TableTransformers;
 
 /**
  * Pattern-based story parser, which uses the keywords provided to parse the
@@ -33,7 +24,7 @@ import org.jbehave.core.model.TableTransformers;
  */
 public class RegexStoryParser implements StoryParser {
 
-    private static final String NONE = "";
+    protected static final String NONE = "";
     private final Keywords keywords;
     private final ExamplesTableFactory tableFactory;
 
@@ -75,12 +66,17 @@ public class RegexStoryParser implements StoryParser {
         Narrative narrative = parseNarrativeFrom(storyAsText);
         GivenStories givenStories = parseGivenStories(storyAsText);
         Lifecycle lifecycle = parseLifecycle(storyAsText);
+        Templates templates = new RegexTemplatesParser(this).parseTemplatesFrom(storyAsText);
         List<Scenario> scenarios = parseScenariosFrom(storyAsText);
         Story story = new Story(storyPath, description, meta, narrative, givenStories, lifecycle, scenarios);
         if (storyPath != null) {
             story.namedAs(new File(storyPath).getName());
         }
         return story;
+    }
+
+    protected Keywords getKeywords() {
+        return keywords;
     }
 
     private Description parseDescriptionFrom(String storyAsText) {
@@ -264,7 +260,7 @@ public class RegexStoryParser implements StoryParser {
         return new Scenario(title, meta, givenStories, examplesTable, steps);
     }
 
-    private String startingWithNL(String text) {
+    protected static String startingWithNL(String text) {
         if ( !text.startsWith("\n") ){ // always ensure starts with newline
             return "\n" + text;
         }
@@ -297,7 +293,7 @@ public class RegexStoryParser implements StoryParser {
         return new GivenStories(givenStories);
     }
 
-    private List<String> findSteps(String stepsAsText) {
+    protected List<String> findSteps(String stepsAsText) {
         Matcher matcher = findingSteps().matcher(stepsAsText);
         List<String> steps = new ArrayList<String>();
         int startAt = 0;
@@ -384,11 +380,11 @@ public class RegexStoryParser implements StoryParser {
         return compile("\\n" + keywords.examplesTable() + "\\s*(.*)", DOTALL);
     }
 
-    private String concatenateWithOr(String... keywords) {
+    protected static String concatenateWithOr(String... keywords) {
         return concatenateWithOr(null, null, keywords);
     }
 
-    private String concatenateWithOr(String beforeKeyword, String afterKeyword, String[] keywords) {
+    protected static String concatenateWithOr(String beforeKeyword, String afterKeyword, String[] keywords) {
         StringBuilder builder = new StringBuilder();
         String before = beforeKeyword != null ? beforeKeyword : NONE;
         String after = afterKeyword != null ? afterKeyword : NONE;

--- a/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexStoryParser.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexStoryParser.java
@@ -311,7 +311,6 @@ public class RegexStoryParser implements StoryParser {
         Matcher matcher = findingStepsWithTemplate().matcher(stepsAsText);
         List<String> steps = new ArrayList<String>();
         int startAt = 0;
-        // TODO Step extraction of givenTemplate is not workign
         while (matcher.find(startAt)) {
             steps.add(StringUtils.substringAfter(matcher.group(1), "\n"));
             startAt = matcher.start(4);
@@ -384,18 +383,16 @@ public class RegexStoryParser implements StoryParser {
     }
 
     private Pattern findingStepsWithTemplate() {
-        List<String> startingWords = Arrays.asList(keywords.startingWords());
-        startingWords.add(keywords.givenTemplate());
-        String initialStartingWords = concatenateWithOr("\\n", "", startingWords.toArray(new String[]{}));
-        String followingStartingWords = concatenateWithOr("\\n", "\\s", );
-        return compile(
-                "((" + initialStartingWords + "|" + keywords.givenTemplate() + ")\\s(.)*?)\\s*(\\Z|" + followingStartingWords + "|\\n"
-                        + keywords.examplesTable() + ")", DOTALL);
+        return findingSteps(keywords.givenTemplate());
     }
 
-    private Pattern findingSteps() {
-        String initialStartingWords = concatenateWithOr("\\n", "", keywords.startingWords());
-        String followingStartingWords = concatenateWithOr("\\n", "\\s", keywords.startingWords());
+    private Pattern findingSteps(String... additionalStartingWords) {
+        List<String> startingWords = new ArrayList<String>(Arrays.asList(keywords.startingWords()));
+        startingWords.addAll(Arrays.asList(additionalStartingWords));
+        String[] startWords = startingWords.toArray(new String[]{});
+
+        String initialStartingWords = concatenateWithOr("\\n", "", startWords);
+        String followingStartingWords = concatenateWithOr("\\n", "\\s", startWords);
         return compile(
                 "((" + initialStartingWords + ")\\s(.)*?)\\s*(\\Z|" + followingStartingWords + "|\\n"
                         + keywords.examplesTable() + ")", DOTALL);

--- a/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexTemplatesParser.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexTemplatesParser.java
@@ -1,0 +1,92 @@
+package org.jbehave.core.parsers;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jbehave.core.configuration.Keywords;
+import org.jbehave.core.model.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.DOTALL;
+import static java.util.regex.Pattern.compile;
+import static org.apache.commons.lang3.StringUtils.removeStart;
+import static org.jbehave.core.parsers.RegexStoryParser.NONE;
+import static org.jbehave.core.parsers.RegexStoryParser.concatenateWithOr;
+import static org.jbehave.core.parsers.RegexStoryParser.startingWithNL;
+
+public class RegexTemplatesParser {
+
+    private RegexStoryParser storyParser;
+    private final Keywords keywords;
+
+    public RegexTemplatesParser(RegexStoryParser storyParser) {
+        this.storyParser = storyParser;
+        this.keywords = storyParser.getKeywords();
+    }
+
+    protected Templates parseTemplatesFrom(String storyAsText) {
+        List<Template> parsed = new ArrayList<Template>();
+        for (String splitted : splitTemplates(storyAsText)) {
+            Template template = parseTemplate(splitted);
+            if (template != null) {
+                parsed.add(template);
+            }
+        }
+        return new Templates(parsed);
+    }
+
+    private List<String> splitTemplates(String storyAsText) {
+        List<String> templates = new ArrayList<String>();
+        String templateKeyword = keywords.template();
+
+        String templateText = findTemplateText(storyAsText);
+
+        for (String templateAsText : templateText.split(templateKeyword)) {
+            if (templateAsText.trim().length() > 0) {
+                templates.add(templateKeyword + "\n" + templateAsText);
+            }
+        }
+
+        return templates;
+    }
+
+    private Template parseTemplate(String templateAsText) {
+        String title = findTemplateTitle(templateAsText);
+        if (StringUtils.isEmpty(title)) {
+            throw new IllegalArgumentException("The title of a template is not filled. Please fill the title.");
+        }
+        String templateWithoutKeyword = removeStart(templateAsText, keywords.template()).trim();
+        String templateWithoutTitle = removeStart(templateWithoutKeyword, title);
+        templateWithoutTitle = startingWithNL(templateWithoutTitle);
+
+        List<String> steps = storyParser.findSteps(templateWithoutTitle);
+        return new Template(title, steps);
+    }
+
+    private String findTemplateText(String storyAsText) {
+        Matcher matcher = findingTemplate().matcher(storyAsText);
+        return matcher.find() ? matcher.group(1).trim() : RegexStoryParser.NONE;
+    }
+
+    private String findTemplateTitle(String templateAsText) {
+        Matcher findingTitle = findingTemplateTitle().matcher(templateAsText);
+        return findingTitle.find() ? findingTitle.group(1).trim() : NONE;
+    }
+
+    private Pattern findingTemplates() {
+        String someString = concatenateWithOr(keywords.givenStories(), keywords.lifecycle(), keywords.scenario(), keywords.narrative());
+        return compile("(" + keywords.givenTemplate() + ".*?)\\s*(" + someString + ").*", DOTALL);
+    }
+
+    private Pattern findingTemplate() {
+        String stopWords = concatenateWithOr(keywords.givenStories(), keywords.lifecycle(), keywords.scenario(), keywords.narrative());
+        return compile("(" + keywords.template() + ".*?)\\s*(" + stopWords + ").*", DOTALL);
+    }
+
+    private Pattern findingTemplateTitle() {
+        String startingWords = concatenateWithOr("\\n", "", keywords.startingWords());
+        return compile(keywords.template() + "(.*?)\\s*(" + startingWords + "|$).*", DOTALL);
+    }
+}

--- a/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexTemplatesParser.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexTemplatesParser.java
@@ -1,5 +1,7 @@
 package org.jbehave.core.parsers;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.jbehave.core.configuration.Keywords;
 import org.jbehave.core.model.*;
@@ -16,28 +18,88 @@ import static org.jbehave.core.parsers.RegexStoryParser.NONE;
 import static org.jbehave.core.parsers.RegexStoryParser.concatenateWithOr;
 import static org.jbehave.core.parsers.RegexStoryParser.startingWithNL;
 
-// TODO validate unique titles for templates
+/**
+ * Pattern-based parser for matching template related keywords.
+ */
 public class RegexTemplatesParser {
 
     private RegexStoryParser storyParser;
     private final Keywords keywords;
-    private final Pattern findGivenTemplate;
+    private static boolean isInitialized = false;
+    private static Pattern givenTemplatePattern;
+    private static Pattern templatePattern;
+    private static Pattern templateTitlePattern;
 
     public RegexTemplatesParser(RegexStoryParser storyParser) {
         this.storyParser = storyParser;
         this.keywords = storyParser.getKeywords();
-        findGivenTemplate = compile(keywords.givenTemplate() + "(.*)", DOTALL);
+        initializePatterns();
     }
 
-    protected Templates parseTemplatesFrom(String storyAsText) {
+    public Templates parseTemplatesFrom(String storyAsText) {
         List<Template> parsed = new ArrayList<Template>();
-        for (String splitted : splitTemplates(storyAsText)) {
-            Template template = parseTemplate(splitted);
-            if (template != null) {
-                parsed.add(template);
+        for (String split : splitTemplates(storyAsText)) {
+            parsed.add(parseTemplate(split));
+        }
+        assertNoDuplicateTitles(parsed);
+        return new Templates(parsed);
+    }
+
+    /**
+     * Replaces GivenTemplate: steps with the according template steps.
+     * @param steps The original step list. Will NOT be modified.
+     * @param templates The collected templates from the story. See {@link #parseTemplatesFrom(String)}.
+     * @return New step list with all included steps.
+     */
+    public List<String> includeTemplateInSteps(List<String> steps, Templates templates) {
+        List<String> extendedSteps = new ArrayList<String>();
+
+        for (String step : steps) {
+            Matcher matcher = givenTemplatePattern.matcher(step);
+            if (matcher.find()) {
+                String templateTitle = matcher.group(1).trim();
+                Template template = templates.getTemplateWithTitle(templateTitle);
+
+                if (template == null) {
+                    throw new IllegalStateException("No template found for template name '" + templateTitle + "'");
+                }
+
+                extendedSteps.addAll(template.getSteps());
+            } else {
+                extendedSteps.add(step);
             }
         }
-        return new Templates(parsed);
+
+        return extendedSteps;
+    }
+
+    private void initializePatterns() {
+        if (isInitialized) {
+            return;
+        }
+
+        if (keywords == null) {
+            throw new IllegalStateException("Cannot initialize template parser if keyword parameter is null.");
+        }
+
+        givenTemplatePattern = compile(keywords.givenTemplate() + "(.*)", DOTALL);
+
+        String stopWords = concatenateWithOr(keywords.givenStories(), keywords.lifecycle(), keywords.scenario(), keywords.narrative());
+        templatePattern = compile("(" + keywords.template() + ".*?)\\s*(" + stopWords + ").*", DOTALL);
+
+        String startingWords = concatenateWithOr("\\n", "", keywords.startingWords());
+        templateTitlePattern = compile(keywords.template() + "(.*?)\\s*(" + startingWords + "|$).*", DOTALL);
+
+        isInitialized = true;
+    }
+
+    private void assertNoDuplicateTitles(List<Template> parsed) {
+        Set<String> checkDuplicate = new HashSet<String>();
+        for (Template template : parsed) {
+            if (!checkDuplicate.add(template.getTitle())) {
+                throw new IllegalStateException("Duplicate title in templates found for '" + template.getTitle() + "'");
+            }
+        }
     }
 
     private List<String> splitTemplates(String storyAsText) {
@@ -69,49 +131,12 @@ public class RegexTemplatesParser {
     }
 
     private String findTemplateText(String storyAsText) {
-        Matcher matcher = findingTemplate().matcher(storyAsText);
+        Matcher matcher = templatePattern.matcher(storyAsText);
         return matcher.find() ? matcher.group(1).trim() : RegexStoryParser.NONE;
     }
 
     private String findTemplateTitle(String templateAsText) {
-        Matcher findingTitle = findingTemplateTitle().matcher(templateAsText);
+        Matcher findingTitle = templateTitlePattern.matcher(templateAsText);
         return findingTitle.find() ? findingTitle.group(1).trim() : NONE;
-    }
-
-    private Pattern findingTemplates() {
-        String someString = concatenateWithOr(keywords.givenStories(), keywords.lifecycle(), keywords.scenario(), keywords.narrative());
-        return compile("(" + keywords.givenTemplate() + ".*?)\\s*(" + someString + ").*", DOTALL);
-    }
-
-    private Pattern findingTemplate() {
-        String stopWords = concatenateWithOr(keywords.givenStories(), keywords.lifecycle(), keywords.scenario(), keywords.narrative());
-        return compile("(" + keywords.template() + ".*?)\\s*(" + stopWords + ").*", DOTALL);
-    }
-
-    private Pattern findingTemplateTitle() {
-        String startingWords = concatenateWithOr("\\n", "", keywords.startingWords());
-        return compile(keywords.template() + "(.*?)\\s*(" + startingWords + "|$).*", DOTALL);
-    }
-
-    public List<String> includeTemplateInSteps(List<String> steps, Templates templates) {
-        List<String> extendedSteps = new ArrayList<String>();
-
-        for (String step : steps) {
-            Matcher matcher = findGivenTemplate.matcher(step);
-            if (matcher.find()) {
-                String templateTitle = matcher.group(1).trim();
-                Template template = templates.getTemplateWithTitle(templateTitle);
-
-                if (template == null) {
-                    throw new IllegalStateException("No template found for template name '" + templateTitle + "'");
-                }
-
-                extendedSteps.addAll(template.getSteps());
-            } else {
-                extendedSteps.add(step);
-            }
-        }
-
-        return extendedSteps;
     }
 }

--- a/jbehave-core/src/main/resources/i18n/keywords_en.properties
+++ b/jbehave-core/src/main/resources/i18n/keywords_en.properties
@@ -36,4 +36,6 @@ OutcomeMatcher=Matcher
 OutcomeVerified=Verified
 MetaFilter=MetaFilter:
 Yes=Yes
-No=NoTemplate=Template:
+No=No
+GivenTemplate=GivenTemplate:
+Template=Template:

--- a/jbehave-core/src/main/resources/i18n/keywords_en.properties
+++ b/jbehave-core/src/main/resources/i18n/keywords_en.properties
@@ -36,4 +36,4 @@ OutcomeMatcher=Matcher
 OutcomeVerified=Verified
 MetaFilter=MetaFilter:
 Yes=Yes
-No=No
+No=NoTemplate=Template:

--- a/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexStoryParserBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexStoryParserBehaviour.java
@@ -931,6 +931,6 @@ public class RegexStoryParserBehaviour {
         List<Scenario> scenarios = story.getScenarios();
         assertThat(scenarios, hasSize(1));
         assertThat(scenarios.get(0).getTitle(), equalTo("Test include template"));
-        assertThat(scenarios.get(0).getSteps(), hasSize(7));
+        assertThat(scenarios.get(0).getSteps(), hasSize(8));
     }
 }

--- a/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexStoryParserBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexStoryParserBehaviour.java
@@ -2,12 +2,7 @@ package org.jbehave.core.parsers;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -916,4 +911,26 @@ public class RegexStoryParserBehaviour {
         return builder.toString();
     }
 
+    @Test
+    public void shouldParseStoryWithTemplate() {
+        String wholeStory = "Template: SomeTemplate" + NL +
+                "Given something in template" + NL +
+                "When you use that template" + NL +
+                "Given something in template" + NL +
+                "When you use that template" + NL +
+
+                "Scenario: Test include template" + NL +
+                "GivenTemplate: SomeTemplate" + NL +
+                "Given a scenario" + NL +
+                "!-- ignore me" + NL +
+                "When I parse it" + NL +
+                "Then I should get steps";
+
+        Story story = parser.parseStory(wholeStory, storyPath);
+        assertThat(story.getPath(), equalTo(storyPath));
+        List<Scenario> scenarios = story.getScenarios();
+        assertThat(scenarios, hasSize(1));
+        assertThat(scenarios.get(0).getTitle(), equalTo("Test include template"));
+        assertThat(scenarios.get(0).getSteps(), hasSize(7));
+    }
 }

--- a/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexTemplatesParserTest.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexTemplatesParserTest.java
@@ -2,17 +2,16 @@ package org.jbehave.core.parsers;
 
 import org.hamcrest.Matchers;
 import org.jbehave.core.i18n.LocalizedKeywords;
-import org.jbehave.core.model.Story;
 import org.jbehave.core.model.TableTransformers;
 import org.jbehave.core.model.Template;
 import org.jbehave.core.model.Templates;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 public class RegexTemplatesParserTest {
 
@@ -111,4 +110,27 @@ public class RegexTemplatesParserTest {
         assertThat(templates.getTemplates().get(0).getTitle(), equalTo("SomeTemplate"));
         assertThat(templates.getTemplates().get(0).getSteps(), hasSize(2));
     }
+
+    @Test
+    public void shouldReplaceTemplateCorrectly() throws Exception {
+        String wholeStory = "Template: SomeTemplate" + NL +
+                "Given some hunk" + NL +
+                "When you crash that" + NL +
+
+                "Scenario: Test" + NL +
+                "GivenTemplate: SomeTemplate" + NL +
+                "Given a scenario" + NL +
+                "!-- ignore me" + NL +
+                "When I parse it" + NL +
+                "Then I should get steps";
+
+        RegexTemplatesParser templatesParser = new RegexTemplatesParser(parser);
+        Templates templates = templatesParser.parseTemplatesFrom(wholeStory);
+
+        List<String> steps = Arrays.asList("GivenTemplate: SomeTemplate" + NL, "Given a scenario");
+        List<String> newSteps = templatesParser.includeTemplateInSteps(steps, templates);
+
+        assertThat(newSteps, hasSize(3));
+    }
+
 }

--- a/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexTemplatesParserTest.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexTemplatesParserTest.java
@@ -93,6 +93,21 @@ public class RegexTemplatesParserTest {
         new RegexTemplatesParser(parser).parseTemplatesFrom(wholeStory);
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void shouldFailOnDuplicateTitle() throws Exception {
+        String wholeStory = "Template: Duplicate" + NL +
+                "Given some hunk" + NL +
+                "Template: Duplicate" + NL +
+                "Given some hunk" + NL +
+                "Scenario: Test" + NL +
+                "Given a scenario" + NL +
+                "!-- ignore me" + NL +
+                "When I parse it" + NL +
+                "Then I should get steps";
+
+        new RegexTemplatesParser(parser).parseTemplatesFrom(wholeStory);
+    }
+
     @Test
     public void shouldNormallyProcessWithGivenTemplate() throws Exception {
         String wholeStory = "Template: SomeTemplate" + NL +

--- a/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexTemplatesParserTest.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexTemplatesParserTest.java
@@ -1,0 +1,114 @@
+package org.jbehave.core.parsers;
+
+import org.hamcrest.Matchers;
+import org.jbehave.core.i18n.LocalizedKeywords;
+import org.jbehave.core.model.Story;
+import org.jbehave.core.model.TableTransformers;
+import org.jbehave.core.model.Template;
+import org.jbehave.core.model.Templates;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class RegexTemplatesParserTest {
+
+    private static final String NL = "\n";
+    private RegexStoryParser parser = new RegexStoryParser(new LocalizedKeywords(), new TableTransformers());
+
+    @Test
+    public void shouldParseOneTemplateFromStory() throws Exception {
+        String wholeStory = "Template: Some title" + NL +
+                "Given some hunk" + NL +
+                "When you crash that" + NL +
+                "Scenario: Test" + NL +
+                "Given a scenario" + NL +
+                "!-- ignore me" + NL +
+                "When I parse it" + NL +
+                "Then I should get steps";
+        Templates templates = new RegexTemplatesParser(parser).parseTemplatesFrom(wholeStory);
+
+        assertThat(templates.getTemplates(), hasSize(1));
+        assertThat(templates.getTemplates().get(0).getTitle(), equalTo("Some title"));
+        assertThat(templates.getTemplates().get(0).getSteps(), hasSize(2));
+    }
+
+    @Test
+    public void shouldParseMultipleTemplatesFromStory() throws Exception {
+        String wholeStory = "Template: FancyTitle" + NL +
+                "Given some hunk" + NL +
+                "When you crash that" + NL +
+                "Given some hunk" + NL +
+                "When you crash that" + NL +
+
+                "Template: Title1" + NL +
+                "Given some hunk" + NL +
+
+                "Template: EmptyTemplate" + NL +
+
+                "Template: Title2" + NL +
+                "Given some hunk" + NL +
+                "When you crash that" + NL +
+
+                "Scenario: Test" + NL +
+                "Given a scenario" + NL +
+                "!-- ignore me" + NL +
+                "When I parse it" + NL +
+                "Then I should get steps";
+
+        Templates templates = new RegexTemplatesParser(parser).parseTemplatesFrom(wholeStory);
+
+        assertThat(templates.getTemplates(), hasSize(4));
+
+        Template template0 = templates.getTemplates().get(0);
+        assertThat(template0.getTitle(), equalTo("FancyTitle"));
+        assertThat(template0.getSteps(), hasSize(4));
+
+        Template template1 = templates.getTemplates().get(1);
+        assertThat(template1.getTitle(), equalTo("Title1"));
+        assertThat(template1.getSteps(), hasSize(1));
+
+        Template template2 = templates.getTemplates().get(2);
+        assertThat(template2.getTitle(), equalTo("EmptyTemplate"));
+        assertThat(template2.getSteps(), is(Matchers.<String>empty()));
+
+        Template template3 = templates.getTemplates().get(3);
+        assertThat(template3.getTitle(), equalTo("Title2"));
+        assertThat(template3.getSteps(), hasSize(2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailWithEmptyTemplateTitle() throws Exception {
+        String wholeStory = "Template:" + NL +
+                "Given some hunk" + NL +
+                "When you crash that" + NL +
+                "Scenario: Test" + NL +
+                "Given a scenario" + NL +
+                "!-- ignore me" + NL +
+                "When I parse it" + NL +
+                "Then I should get steps";
+
+        new RegexTemplatesParser(parser).parseTemplatesFrom(wholeStory);
+    }
+
+    @Test
+    public void shouldNormallyProcessWithGivenTemplate() throws Exception {
+        String wholeStory = "Template: SomeTemplate" + NL +
+                "Given some hunk" + NL +
+                "When you crash that" + NL +
+                "Scenario: Test" + NL +
+                "GivenTemplate: SomeTemplate" + NL +
+                "Given a scenario" + NL +
+                "!-- ignore me" + NL +
+                "When I parse it" + NL +
+                "Then I should get steps";
+        Templates templates = new RegexTemplatesParser(parser).parseTemplatesFrom(wholeStory);
+
+        assertThat(templates.getTemplates(), hasSize(1));
+        assertThat(templates.getTemplates().get(0).getTitle(), equalTo("SomeTemplate"));
+        assertThat(templates.getTemplates().get(0).getSteps(), hasSize(2));
+    }
+}


### PR DESCRIPTION
I added following functionality (currently only in the scenario usable).
We can define Templates which will be substituted in the scenario with the keyword GivenTemplate: someLabel. This is useful if we have many steps which are the same and therefore would be duplicated and we cannot use the parameterized values to fully cover all necessary steps.
The substitution will take place even before the story parsing is fully completed. This means after the story parsing we will have a scenario without knowing that there has been a template.

More concrete example:

Template: Do something in the beginning
Given a step
When we do something
Then something happens

Scenario: 
GivenTemplate: Do something in the beginning
When we have done something
Then we can continue with this

Which would be resolved to:

Scenario: 
Given a step
When we do something
Then something happens
When we have done something
Then we can continue with this

This would be a very useful functionality for us. Feel free to comment and provide ideas for improvement :)
