### PR TITLE
Added replaceNamedParameters flag to ExampleTable.getRowsAs

### DIFF
--- a/jbehave-core/src/main/java/org/jbehave/core/model/ExamplesTable.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/model/ExamplesTable.java
@@ -359,13 +359,21 @@ public class ExamplesTable {
     }
 
     public <T> List<T> getRowsAs(Class<T> type) {
-        return getRowsAs(type, new HashMap<String, String>());
+        return getRowsAs(type, Collections.emptyMap(), false);
+    }
+
+    public <T> List<T> getRowsAs(Class<T> type, boolean replaceNamedParameters) {
+        return getRowsAs(type, Collections.emptyMap(), replaceNamedParameters);
     }
 
     public <T> List<T> getRowsAs(Class<T> type, Map<String, String> fieldNameMapping) {
+        return getRowsAs(type, fieldNameMapping, false);
+    }
+
+    public <T> List<T> getRowsAs(Class<T> type, Map<String, String> fieldNameMapping, boolean replaceNamedParameters) {
         List<T> rows = new ArrayList<>();
 
-        for (Parameters parameters : getRowsAsParameters()) {
+        for (Parameters parameters : getRowsAsParameters(replaceNamedParameters)) {
             rows.add(mapToType(parameters, type, fieldNameMapping));
         }
 


### PR DESCRIPTION
A flag to substitute named parameters added into the API for parsing `ExampleTable` row into a custom type.