### PR TITLE
JBEHAVE-1350 Fix typo of omitted field "tableTransformers" in CrossReference

### DIFF
--- a/jbehave-core/src/main/java/org/jbehave/core/reporters/CrossReference.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/reporters/CrossReference.java
@@ -130,7 +130,7 @@ public class CrossReference {
 		xstream.alias("stepMatch", StepMatch.class);
 		xstream.alias("timing", Timing.class);
 		xstream.omitField(ExamplesTable.class, "parameterConverters");
-		xstream.omitField(ExamplesTable.class, "tableTrasformers");
+		xstream.omitField(ExamplesTable.class, "tableTransformers");
 		xstream.omitField(ExamplesTable.class, "defaults");
 	}
 


### PR DESCRIPTION
by fixing the typo