### PR TITLE
JBEHAVE-1569 Use JDK collections instead of Guava ones

### DIFF
--- a/distribution/src/checkstyle/jbehave-checks.xml
+++ b/distribution/src/checkstyle/jbehave-checks.xml
@@ -240,6 +240,11 @@
       <property name="specialImportsRegExp" value="^org\."/>
       <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
     </module>
+    <module name="IllegalImport">
+      <property name="id" value="bannedGuavaCollectionsInFavorOfJdkCollections" />
+      <property name="regexp" value="true" />
+      <property name="illegalClasses" value="^com\.google\.common\.collect\..*" />
+    </module>
     <module name="MethodParamPad">
       <property name="tokens"
                 value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,

--- a/jbehave-core/src/main/java/org/jbehave/core/junit/JUnit4StoryReporter.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/junit/JUnit4StoryReporter.java
@@ -1,6 +1,7 @@
 package org.jbehave.core.junit;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -12,8 +13,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
-
-import com.google.common.collect.ImmutableList;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.jbehave.core.configuration.Keywords;
@@ -95,7 +94,7 @@ public class JUnit4StoryReporter extends NullStoryReporter {
             notifier.fireTestStarted(storyDescription);
 
             if (storyDescription.isSuite()) {
-                testState.scenarioDescriptions = filter(storyDescription.getChildren(), ImmutableList.of(
+                testState.scenarioDescriptions = filter(storyDescription.getChildren(), Arrays.asList(
                     Pair.of(ElementAction.DROP, isTest()),
                     Pair.of(ElementAction.TAKE, isSuite())
                 )).iterator();
@@ -113,13 +112,13 @@ public class JUnit4StoryReporter extends NullStoryReporter {
         if (!testState.isGivenStoryRunning()) {
 
             if (stage == Stage.BEFORE && type == Lifecycle.ExecutionType.SYSTEM) {
-                loadStepDescriptions(filter(testState.getStoryChildren(), ImmutableList.of(
+                loadStepDescriptions(filter(testState.getStoryChildren(), Collections.singletonList(
                     Pair.of(ElementAction.TAKE, isTest())
                 )));
             }
 
             if (stage == Stage.AFTER && type == Lifecycle.ExecutionType.USER) {
-                loadStepDescriptions(filter(testState.getStoryChildren(), ImmutableList.of(
+                loadStepDescriptions(filter(testState.getStoryChildren(), Arrays.asList(
                     Pair.of(ElementAction.DROP, isTest()),
                     Pair.of(ElementAction.DROP, isSuite()),
                     Pair.of(ElementAction.TAKE, isTest())

--- a/jbehave-core/src/test/java/org/jbehave/core/embedder/PerformableTreeBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/embedder/PerformableTreeBehaviour.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Type;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -33,8 +34,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-
-import com.google.common.collect.ImmutableMap;
 
 import org.jbehave.core.annotations.Composite;
 import org.jbehave.core.annotations.Scope;
@@ -109,9 +108,11 @@ class PerformableTreeBehaviour {
         Meta storyMeta = new Meta();
         Story story = new Story(STORY_PATH, null, storyMeta, null, singletonList(scenario));
 
+        Map<Stage, List<Step>> lifecycleSteps = new LinkedHashMap<>();
+        lifecycleSteps.put(Stage.BEFORE, emptyList());
+        lifecycleSteps.put(Stage.AFTER, emptyList());
         when(stepCollector.collectLifecycleSteps(eq(stepCandidates), eq(story.getLifecycle()), eq(storyMeta),
-                eq(Scope.STORY), any(MatchingStepMonitor.class)))
-                        .thenReturn(ImmutableMap.of(Stage.BEFORE, emptyList(), Stage.AFTER, emptyList()));
+                eq(Scope.STORY), any(MatchingStepMonitor.class))).thenReturn(lifecycleSteps);
 
         PerformableTree performableTree = new PerformableTree();
         PerformableTree.RunContext runContext = performableTree.newRunContext(configuration, allStepCandidates,


### PR DESCRIPTION
`guava` dependemcy is optional, it's needed only if `org.jbehave.core.embedder.executors.DirectExecutorService` is used. All other usages of `guava` dependeny are prohibited in order to keep dependency tree clean.