### PR TITLE
JBEHAVE-1606 Handle dynamic table meta only at scenario execution level

### DIFF
--- a/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexStoryParser.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/parsers/RegexStoryParser.java
@@ -402,9 +402,8 @@ public class RegexStoryParser extends AbstractRegexParser implements StoryParser
 
     private Pattern findingScenarioMeta() {
         String startingWords = concatenateStartingWords();
-        return compile(
-                ".*" + keywords().meta() + "(.*?)\\s*(" + keywords().givenStories() + "|" + startingWords + "|$).*",
-                DOTALL);
+        return compile(".*^\\s*" + keywords().meta() + "(.*?)\\s*(" + keywords().givenStories() + "|" + startingWords
+                + "|$).*", DOTALL);
     }
 
     private Pattern findingScenarioGivenStories() {

--- a/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexStoryParserBehaviour.java
+++ b/jbehave-core/src/test/java/org/jbehave/core/parsers/RegexStoryParserBehaviour.java
@@ -305,7 +305,29 @@ class RegexStoryParserBehaviour {
                             + NL + "|Dado que|Quando|Então|E|"
                             + NL));
     }
-    
+
+    @Test
+    void shouldNotParseExamplesTableMetaAsScenarioMeta() {
+        String wholeStory = "Scenario: Scenario with examples table containing meta"
+                + NL + "Given a scenario Given"
+                + NL + "Examples:"
+                + NL + "|Meta:    |value|"
+                + NL + "|@number 1|one  |"
+                + NL + "|@number 2|two  |" + NL;
+        Story story = parser.parseStory(wholeStory, storyPath);
+
+        Scenario scenario = story.getScenarios().get(0);
+        assertThat(scenario.getTitle(), equalTo("Scenario with examples table containing meta"));
+        List<String> steps = scenario.getSteps();
+        assertThat(steps.get(0), equalTo("Given a scenario Given"));
+        assertThat(scenario.getExamplesTable().asString(),
+                    equalTo("|Meta:|value|"
+                            + NL + "|@number 1|one|"
+                            + NL + "|@number 2|two|"
+                            + NL));
+        assertThat(scenario.getMeta().isEmpty(), is(true));
+    }
+
     @Test
     void shouldParseStoryWithLifecycle() {
         String wholeStory = "Lifecycle: "


### PR DESCRIPTION
Examples table meta should not be parsed along with scenario meta because unlike scenario meta, the table row is local to particular row being filtered which is unknown at the time of regex story parsing but at runtime, this logic is performed in PerformableTree where scenario parameters are checked for the meta in rows.